### PR TITLE
Tell dnsmasq not to pass requests upstream (#223)

### DIFF
--- a/scripts/create-dnsmasq.sh
+++ b/scripts/create-dnsmasq.sh
@@ -52,10 +52,12 @@ while read -r entry; do
                                 fi
                                 parsed=$(echo ${fileentry} | sed -e "s/^\*\.//")
                                 for i in ${cacheip}; do
-                                        if grep -qx "address=/${parsed}/${i}" "${outputfile}"; then
-                                                continue
+                                        if ! grep -qx "address=/${parsed}/${i}" "${outputfile}"; then
+                                                echo "address=/${parsed}/${i}" >> "${outputfile}"
                                         fi
-                                        echo "address=/${parsed}/${i}" >> "${outputfile}"
+                                        if ! grep -qx "local=/${parsed}/" "${outputfile}"; then
+                                                echo "local=/${parsed}/" >> "${outputfile}"
+                                        fi
                                 done
                         done <<< $(cat ${basedir}/${filename} | sort);
                 done <<< $(jq -r ".cache_domains[${entry}].domain_files[$fileid]" ${path})


### PR DESCRIPTION
* Tell dnsmasq not to pass requests upstream

The behavior of dnsmasq changed in version 2.86 -- before then, if a record was set for a domain name with dnsmasq, and a record for a type not specified for that domain was requested, dnsmasq would indicate no data existed for that record type. After 2.86, record types that are not specified are instead passed upstream. The latter behavior causes problems for, e.g., the Steam client, which will disregard a correctly set A-record for lancache.steamcontent.com, if no AAAA is set with dnsmasq and dnsmasq passes the AAAA query upstream. The documentation for dnsmasq indicates the correct way to restore the old behavior is to use the local=/host/ syntax -- emit this syntax for each of our lancache-hosted DNS entries.

* Update scripts/create-dnsmasq.sh



---------

### What CDN does this PR relate to
<!-- Please clearly state what existing cdn this pr relates to, or which games if it's a new cdn -->

### Does this require running via sniproxy
<!-- Yes/no/untested -->

### Capture method
<!-- Please give a short description how you ascertained the updates to the domain files, wireshark, dns logs etc -->

### Testing Scenario
<!-- Please give a short description on how you have tested this and where (home, office, small lan, large lan etc) -->

### Testing Configuration
```
<!-- Paste either your docker run command from the DNS container OR explain how you have setup DNS zone files etc to test this issue -->
```

### Sniproxy output
Please paste the output from `docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c` below
```
<!-- If you are running sniproxy paste the output to the following command
docker logs <sniproxy container name/id> | sed 's/.*\:443 \[//;s/\].*//' | sort | uniq -c
-->
```

